### PR TITLE
Drop PHP 8 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": "^8 || ^7.4",
+    "php": "^7.4",
     "ext-parallel": "^1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1569ff26a41a968dda5cdd7cc90f7e7b",
+    "content-hash": "983675413ce741cd5b424781457600e1",
     "packages": [],
     "packages-dev": [
         {
@@ -8252,7 +8252,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8 || ^7.4",
+        "php": "^7.4",
         "ext-parallel": "^1"
     },
     "platform-dev": [],


### PR DESCRIPTION
PHP 8 isn't fully supported by ext-parallel yet, as experienced while
developing this package.